### PR TITLE
bump go version to 1.16 so that darwin_arm64 builds are also released

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
Signed-off-by: ygelfand <yuri.gelfand@inboxhealth.com>