### PR TITLE
first pass at adding hosts to a server

### DIFF
--- a/internal/pritunl/client.go
+++ b/internal/pritunl/client.go
@@ -29,7 +29,13 @@ type Client interface {
 	UpdateServer(id string, server *Server) error
 	DeleteServer(id string) error
 
+	GetHostsByServer(serverId string) ([]Host, error)
+
+	AttachHostToServer(hostId, serverId string) error
+	DetachHostFromServer(hostId, serverId string) error
+
 	GetOrganizationsByServer(serverId string) ([]Organization, error)
+
 	AttachOrganizationToServer(organizationId, serverId string) error
 	DetachOrganizationFromServer(organizationId, serverId string) error
 
@@ -453,6 +459,63 @@ func (c client) DeleteServer(id string) error {
 	body, _ := ioutil.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("Non-200 response on deleting the server\nbody=%s", body)
+	}
+
+	return nil
+}
+
+func (c client) GetHostsByServer(serverId string) ([]Host, error) {
+	url := fmt.Sprintf("/server/%s/host", serverId)
+	req, err := http.NewRequest("GET", url, nil)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GetHostsByServer: Error on HTTP request: %s", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Non-200 response on getting hosts on the server\nbody=%s", body)
+	}
+
+	var hosts []Host
+	json.Unmarshal(body, &hosts)
+
+	return hosts, nil
+}
+
+func (c client) AttachHostToServer(hostId, serverId string) error {
+	url := fmt.Sprintf("/server/%s/host/%s", serverId, hostId)
+	req, err := http.NewRequest("PUT", url, nil)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("AttachHostToServer: Error on HTTP request: %s", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Non-200 response on attaching a host to the server\nbody=%s", body)
+	}
+
+	return nil
+}
+
+func (c client) DetachHostFromServer(hostId, serverId string) error {
+	url := fmt.Sprintf("/server/%s/host/%s", serverId, hostId)
+	req, err := http.NewRequest("DELETE", url, nil)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("DetachHostFromServer: Error on HTTP request: %s", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Non-200 response on detaching the host from the server\nbody=%s", body)
 	}
 
 	return nil

--- a/internal/pritunl/host.go
+++ b/internal/pritunl/host.go
@@ -1,0 +1,5 @@
+package pritunl
+
+type Host struct {
+	ID   string `json:"id,omitempty"`
+}


### PR DESCRIPTION
Here's my first attempt at adding support for attaching hosts to a server (#3 ).  I followed the the approach you took for host you did this with organizations.

One thing I noticed is that when you create a server, a host gets automatically attached to your server. Not sure what the algorithm for which host pritunl chooses, but in my case its not correct and I want to attach my own hosts.

So I took the approach found in the code for deleting the default route that gets created.

this first pass doesn't include any resources for looking up or managing the pritunl host resources themselves, as I didn't need that functionality.

I'm not sure how best to handle the case that where a user of this provider expects and wants pritunl to manage what host gets attached to the server.

Any feedback is appreciated.  Thanks.