### PR TITLE
Multiple hosts support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 build:
 	go build -gcflags="all=-N -l" -o ~/.terraform.d/plugins/registry.terraform.io/disc/pritunl/0.0.1/darwin_amd64/terraform-provider-pritunl_v0.0.1 main.go
-	rm -rf terraform/.terraform/ terraform/.terraform.lock.hcl
 
 test:
 	@docker rm tf_pritunl_acc_test -f || true
-	@docker run --name tf_pritunl_acc_test --rm -d --privileged -p 1194:1194/udp -p 1194:1194/tcp -p 80:80/tcp -p 443:443/tcp -p 27017:27017/tcp jippi/pritunl
+	@docker run --name tf_pritunl_acc_test --hostname pritunl.local --rm -d --privileged -p 1194:1194/udp -p 1194:1194/tcp -p 80:80/tcp -p 443:443/tcp -p 27017:27017/tcp jippi/pritunl
 
 	sleep 10
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ terraform {
   required_providers {
     pritunl = {
       source  = "disc/pritunl"
-      version = "0.0.7"
+      version = "0.1.0"
     }
   }
 }
@@ -106,6 +106,28 @@ resource "pritunl_server" "example" {
         nat     = route.value["nat"]
       }
   }
+}
+```
+### Multiple hosts per server (Replicated servers feature)
+It also supports multiple host server's configuration with host datasource which can be matched by a hostname.
+```hcl
+data "pritunl_host" "main" {
+  hostname = "nyc1.vpn.host"
+}
+
+data "pritunl_host" "reserve" {
+  hostname = "nyc3.vpn.host"
+}
+
+resource "pritunl_server" "test" {
+  name    = "some-server"
+  network = "192.168.250.0/24"
+  port    = 15500
+
+  host_ids = [
+    data.pritunl_host.main.id,
+    data.pritunl_host.reserve.id,
+  ]
 }
 ```
 

--- a/examples/provider/multiple-hosts/main.tf
+++ b/examples/provider/multiple-hosts/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    pritunl = {
+      version = "0.1.0"
+      source  = "disc/pritunl"
+    }
+  }
+}
+
+provider "pritunl" {
+  url    = var.pritunl_url
+  token  = var.pritunl_api_token
+  secret = var.pritunl_api_secret
+
+  insecure = var.pritunl_insecure
+}
+
+data "pritunl_host" "main" {
+  hostname = "nyc1.vpn.host"
+}
+
+data "pritunl_host" "reserve" {
+  hostname = "nyc3.vpn.host"
+}
+
+resource "pritunl_server" "test" {
+  name    = "some-server"
+  network = "192.168.250.0/24"
+  port    = 15500
+
+  host_ids = [
+    data.pritunl_host.main.id,
+    data.pritunl_host.reserve.id,
+  ]
+}

--- a/examples/provider/multiple-hosts/variables.tf
+++ b/examples/provider/multiple-hosts/variables.tf
@@ -1,0 +1,19 @@
+variable "pritunl_url" {
+  type    = string
+  default = "http://localhost"
+}
+
+variable "pritunl_api_token" {
+  type    = string
+  default = "secret"
+}
+
+variable "pritunl_api_secret" {
+  type    = string
+  default = "secret"
+}
+
+variable "pritunl_insecure" {
+  type    = bool
+  default = false
+}

--- a/internal/pritunl/host.go
+++ b/internal/pritunl/host.go
@@ -1,0 +1,6 @@
+package pritunl
+
+type Host struct {
+	ID       string `json:"id,omitempty"`
+	Hostname string `json:"hostname"`
+}

--- a/internal/provider/data_source_host.go
+++ b/internal/provider/data_source_host.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"github.com/disc/terraform-provider-pritunl/internal/pritunl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceHost() *schema.Resource {
+	return &schema.Resource{
+		Description: "Use this data source to get information about the Pritunl hosts.",
+		ReadContext: dataSourceHostsRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hostname": {
+				Description: "Hostname",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+		},
+	}
+}
+
+func dataSourceHostsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	hostname := d.Get("hostname")
+	filterFunction := func(host pritunl.Host) bool {
+		return host.Hostname == hostname
+	}
+
+	host, err := filterHosts(meta, filterFunction)
+	if err != nil {
+		return diag.Errorf("could not a find host with a hostname %s. Previous error message: %v", hostname, err)
+	}
+
+	d.SetId(host.ID)
+	d.Set("hostname", host.Hostname)
+
+	return nil
+}
+
+func filterHosts(meta interface{}, test func(host pritunl.Host) bool) (pritunl.Host, error) {
+	apiClient := meta.(pritunl.Client)
+
+	hosts, err := apiClient.GetHosts()
+
+	if err != nil {
+		return pritunl.Host{}, err
+	}
+
+	for _, dir := range hosts {
+		if test(dir) {
+			return dir, nil
+		}
+	}
+
+	return pritunl.Host{}, errors.New("could not find a host with specified parameters")
+}

--- a/internal/provider/data_source_host_test.go
+++ b/internal/provider/data_source_host_test.go
@@ -1,0 +1,36 @@
+package provider
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"regexp"
+	"testing"
+)
+
+func TestDataSourceHost(t *testing.T) {
+	// pritunl.local sets in Makefile's "test" target
+	existsHostname := "pritunl.local"
+	notExistHostname := "not-exist-hostname"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() {},
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testdataHostSimpleConfig(existsHostname),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+			{
+				Config:      testdataHostSimpleConfig(notExistHostname),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("could not a find host with a hostname %s. Previous error message: could not find a host with specified parameters", notExistHostname)),
+			},
+		},
+	})
+}
+
+func testdataHostSimpleConfig(name string) string {
+	return fmt.Sprintf(`
+data "pritunl_host" "test" {
+	hostname    = "%[1]s"
+}
+`, name)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -36,6 +36,9 @@ func Provider() *schema.Provider {
 			"pritunl_server":       resourceServer(),
 			"pritunl_user":         resourceUser(),
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"pritunl_host": dataSourceHost(),
+		},
 		ConfigureContextFunc: providerConfigure,
 	}
 }

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -141,7 +141,7 @@ func resourceUserRead(_ context.Context, d *schema.ResourceData, meta interface{
 		if !ok {
 			return diag.Errorf("failed to parse groups for the user: %s", user.Name)
 		}
-		d.Set("groups", matchGroupsWithSchema(groupsList, declaredGroups))
+		d.Set("groups", matchStringEntitiesWithSchema(groupsList, declaredGroups))
 	}
 
 	return nil


### PR DESCRIPTION
Solves #3 
Added new server's attribute `host_ids`
Added new datasource `pritunl_host`

The `host_ids` attribute is computed attribute and contains default attached host.

There is an example of config with multiple hosts support
```
data "pritunl_host" "main" {
  hostname = "nyc1.vpn.host"
}

data "pritunl_host" "reserve" {
  hostname = "nyc3.vpn.host"
}

resource "pritunl_server" "test" {
  name    = "some-server"
  network = "192.168.250.0/24"
  port    = 15500

  host_ids = [
    data.pritunl_host.main.id,
    data.pritunl_host.reserve.id,
  ]
}
```