### PR TITLE
Force replace user on organization_id change

### DIFF
--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -21,6 +21,7 @@ func resourceUser() *schema.Resource {
 			"organization_id": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "The organizations that user belongs to.",
 				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
 					return validation.StringIsNotEmpty(i, s)


### PR DESCRIPTION
Currently, in case of organization change for a Pritunl user, Terraform will just update it.
In practical term, as a consequence, a profile generated for the updated user will contain an unusable certificate issued by the former organization CA.
Considering the fact that the state for the user is their profile - which must be re-generated anyway - I think that a simple way to tackle this issue is to force replacement of the user on organization_id change. 