### PR TITLE
Add 3 retries for host GET connections

### DIFF
--- a/internal/pritunl/client.go
+++ b/internal/pritunl/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 type Client interface {
@@ -759,13 +760,27 @@ func (c client) GetHosts() ([]Host, error) {
 	url := fmt.Sprintf("/host")
 	req, err := http.NewRequest("GET", url, nil)
 
-	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GetHosts: Error creating request: %s", err)
+	}
+
+	var body []byte
+	var resp *http.Response
+	for retries := 0; retries < 3; retries++ {
+		resp, err = c.httpClient.Do(req)
+		if err == nil && resp.StatusCode == 200 {
+			body, _ = io.ReadAll(resp.Body)
+			break
+		}
+		time.Sleep(time.Second)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("GetHosts: Error on HTTP request: %s", err)
 	}
+
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("Non-200 response on getting the hosts\nbody=%s", body)
 	}


### PR DESCRIPTION
Sometimes in configurations with a large number of hosts, the following errors occur:
```
Error: could not a find host with a hostname <hostname>. Previous error message: Non-200 response on getting the hosts
│ body=401: Unauthorized
```

Retrying the request should solve the problem.