### PR TITLE
docs: Fix description of the dns_servers attribure

### DIFF
--- a/internal/provider/resource_server.go
+++ b/internal/provider/resource_server.go
@@ -3,13 +3,14 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net"
+	"strings"
+
 	"github.com/disc/terraform-provider-pritunl/internal/pritunl"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"net"
-	"strings"
 )
 
 func resourceServer() *schema.Resource {
@@ -173,7 +174,7 @@ func resourceServer() *schema.Resource {
 				},
 				Required:    false,
 				Optional:    true,
-				Description: "Enter list of groups to allow connections from. Names are case sensitive. If empty all groups will able to connect",
+				Description: "Enter list of DNS servers applied on the client",
 			},
 			"otp_auth": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
This PR fixes the description of the `dns_servers` parameter as it is currently a copy/paste of  the description of `groups` in the doc (https://registry.terraform.io/providers/disc/pritunl/latest/docs/resources/server)

![image](https://github.com/disc/terraform-provider-pritunl/assets/1116969/f68c3c66-5b8e-4704-9e7a-5190c1e31511)

