### PR TITLE
Feat: add sso_auth parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 		-p 80:80/tcp \
 		-p 443:443/tcp \
 		-p 27017:27017/tcp \
-		ghcr.io/jippi/docker-pritunl:1.30.3236.80
+		ghcr.io/jippi/docker-pritunl:1.32.3602.80
 
 	sleep 20
 

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -56,6 +56,7 @@ description: |-
 - **route** (Block List) The list of attached routes to the server (see [below for nested schema](#nestedblock--route))
 - **search_domain** (String) DNS search domain for clients. Separate multiple search domains by a comma.
 - **session_timeout** (Number) Disconnects users after the specified number of seconds.
+- **sso_auth** (Boolean) Require client to authenticate with single sign-on provider on each connection using web browser.
 - **status** (String) The status of the server
 - **vxlan** (Boolean) Use VXLan for routing client-to-client traffic with replicated servers.
 

--- a/internal/pritunl/client.go
+++ b/internal/pritunl/client.go
@@ -379,6 +379,10 @@ func (c client) CreateServer(serverData map[string]interface{}) (*Server, error)
 		serverStruct.Debug = v.(bool)
 	}
 
+	if v, ok := serverData["sso_auth"]; ok {
+		serverStruct.SsoAuth = v.(bool)
+	}
+
 	if v, ok := serverData["restrict_routes"]; ok {
 		serverStruct.RestrictRoutes = v.(bool)
 	}

--- a/internal/pritunl/server.go
+++ b/internal/pritunl/server.go
@@ -56,7 +56,7 @@ type Server struct {
 	BlockOutsideDns  bool     `json:"block_outside_dns,omitempty"`
 	JumboFrames      bool     `json:"jumbo_frames,omitempty"`
 	Debug            bool     `json:"debug,omitempty"`
-	SsoAuth          bool     `json:"sso_auth"`
+	SsoAuth          bool     `json:"sso_auth,omitempty"`
 	Status           string   `json:"status,omitempty"`
 }
 

--- a/internal/pritunl/server.go
+++ b/internal/pritunl/server.go
@@ -56,7 +56,7 @@ type Server struct {
 	BlockOutsideDns  bool     `json:"block_outside_dns,omitempty"`
 	JumboFrames      bool     `json:"jumbo_frames,omitempty"`
 	Debug            bool     `json:"debug,omitempty"`
-	SsoAuth		     bool	  `json:"sso_auth"`
+	SsoAuth          bool     `json:"sso_auth"`
 	Status           string   `json:"status,omitempty"`
 }
 

--- a/internal/pritunl/server.go
+++ b/internal/pritunl/server.go
@@ -56,6 +56,7 @@ type Server struct {
 	BlockOutsideDns  bool     `json:"block_outside_dns,omitempty"`
 	JumboFrames      bool     `json:"jumbo_frames,omitempty"`
 	Debug            bool     `json:"debug,omitempty"`
+	SsoAuth			 bool	  `json:"sso_auth"`
 	Status           string   `json:"status,omitempty"`
 }
 

--- a/internal/pritunl/server.go
+++ b/internal/pritunl/server.go
@@ -56,7 +56,7 @@ type Server struct {
 	BlockOutsideDns  bool     `json:"block_outside_dns,omitempty"`
 	JumboFrames      bool     `json:"jumbo_frames,omitempty"`
 	Debug            bool     `json:"debug,omitempty"`
-	SsoAuth			 bool	  `json:"sso_auth"`
+	SsoAuth		     bool	  `json:"sso_auth"`
 	Status           string   `json:"status,omitempty"`
 }
 

--- a/internal/provider/resource_server.go
+++ b/internal/provider/resource_server.go
@@ -871,7 +871,7 @@ func resourceUpdateServer(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if d.HasChange("sso_auth") {
-		server.Debug = d.Get("sso_auth").(bool)
+		server.SsoAuth = d.Get("sso_auth").(bool)
 	}
 
 	if d.HasChange("restrict_routes") {

--- a/internal/provider/resource_server.go
+++ b/internal/provider/resource_server.go
@@ -336,6 +336,12 @@ func resourceServer() *schema.Resource {
 				Optional:    true,
 				Description: "Show server debugging information in output.",
 			},
+			"sso_auth": {
+				Type:        schema.TypeBool,
+				Required:    false,
+				Optional:    true,
+				Description: "Require client to authenticate with single sign-on provider on each connection using web browser.",
+			},
 			"restrict_routes": {
 				Type:        schema.TypeBool,
 				Required:    false,
@@ -524,6 +530,7 @@ func resourceReadServer(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("replica_count", server.ReplicaCount)
 	d.Set("multi_device", server.MultiDevice)
 	d.Set("debug", server.Debug)
+	d.Set("sso_auth", server.SsoAuth)
 	d.Set("restrict_routes", server.RestrictRoutes)
 	d.Set("block_outside_dns", server.BlockOutsideDns)
 	d.Set("dns_mapping", server.DnsMapping)
@@ -644,6 +651,7 @@ func resourceCreateServer(ctx context.Context, d *schema.ResourceData, meta inte
 		"replica_count":      d.Get("replica_count"),
 		"multi_device":       d.Get("multi_device"),
 		"debug":              d.Get("debug"),
+		"sso_auth":           d.Get("sso_auth"),
 		"restrict_routes":    d.Get("restrict_routes"),
 		"block_outside_dns":  d.Get("block_outside_dns"),
 		"dns_mapping":        d.Get("dns_mapping"),
@@ -860,6 +868,10 @@ func resourceUpdateServer(ctx context.Context, d *schema.ResourceData, meta inte
 
 	if d.HasChange("debug") {
 		server.Debug = d.Get("debug").(bool)
+	}
+
+	if d.HasChange("sso_auth") {
+		server.Debug = d.Get("sso_auth").(bool)
 	}
 
 	if d.HasChange("restrict_routes") {


### PR DESCRIPTION
### Why ?
`sso_auth` parameter exists in Priutnl servers. 
When set at `true`, it will require client to authenticate with single sign-on provider on each connection using web browser.
It could be usefull to have it. (And I need it, of course)

### How ?
Adding it in provider.

# Bonus

Update pritunl docker image version. 