### PR TITLE
Server's group name validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ terraform {
   required_providers {
     pritunl = {
       source  = "disc/pritunl"
-      version = "0.1.7"
+      version = "0.1.13"
     }
   }
 }

--- a/internal/provider/resource_server.go
+++ b/internal/provider/resource_server.go
@@ -160,12 +160,13 @@ func resourceServer() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					ValidateDiagFunc: func(v interface{}, path cty.Path) diag.Diagnostics {
-						if strings.Contains(v.(string), " ") {
+						groupName := v.(string)
+						if strings.Contains(groupName, " ") {
 							return diag.Diagnostics{
 								{
 									Severity:      diag.Error,
 									Summary:       "Group name must not contain spaces",
-									Detail:        v.(string) + " contains spaces",
+									Detail:        groupName + " contains spaces",
 									AttributePath: cty.Path{cty.GetAttrStep{Name: "groups"}},
 								},
 							}

--- a/internal/provider/resource_server.go
+++ b/internal/provider/resource_server.go
@@ -159,6 +159,20 @@ func resourceServer() *schema.Resource {
 				Type: schema.TypeList,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
+					ValidateDiagFunc: func(v interface{}, path cty.Path) diag.Diagnostics {
+						if strings.Contains(v.(string), " ") {
+							return diag.Diagnostics{
+								{
+									Severity:      diag.Error,
+									Summary:       "Group name must not contain spaces",
+									Detail:        v.(string) + " contains spaces",
+									AttributePath: cty.Path{cty.GetAttrStep{Name: "groups"}},
+								},
+							}
+						}
+
+						return nil
+					},
 				},
 				Required:    false,
 				Optional:    true,


### PR DESCRIPTION
Fixes #41
Added validation for server's groups name that doesn't allow to use spaces in a group name

