### PR TITLE
fix: error when updating a linked servers

### DIFF
--- a/internal/pritunl/client.go
+++ b/internal/pritunl/client.go
@@ -29,6 +29,10 @@ type Client interface {
 	UpdateServer(id string, server *Server) error
 	DeleteServer(id string) error
 
+	GetLinksByServer(serverId string) ([]Link, error)
+	AttachLinkBetweenServers(firstServerId, secondServerId string) error
+	DetachLinkBetweenServers(firstServerId, secondServerId string) error
+
 	GetOrganizationsByServer(serverId string) ([]Organization, error)
 	AttachOrganizationToServer(organizationId, serverId string) error
 	DetachOrganizationFromServer(organizationId, serverId string) error
@@ -472,6 +476,63 @@ func (c client) DeleteServer(id string) error {
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("Non-200 response on deleting the server\nbody=%s", body)
+	}
+
+	return nil
+}
+
+func (c client) GetLinksByServer(serverId string) ([]Link, error) {
+	url := fmt.Sprintf("/server/%s/link", serverId)
+	req, err := http.NewRequest("GET", url, nil)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GetLinksByServer: Error on HTTP request: %s", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Non-200 response on getting links on the server\nbody=%s", body)
+	}
+
+	var links []Link
+	json.Unmarshal(body, &links)
+
+	return links, nil
+}
+
+func (c client) AttachLinkBetweenServers(firstServerId, secondServerId string) error {
+	url := fmt.Sprintf("/server/%s/link/%s", firstServerId, secondServerId)
+	req, err := http.NewRequest("PUT", url, nil)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("AttachLinkBetweenServers: Error on HTTP request: %s", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Non-200 response on attaching an organization the server\nbody=%s", body)
+	}
+
+	return nil
+}
+
+func (c client) DetachLinkBetweenServers(firstServerId, secondServerId string) error {
+	url := fmt.Sprintf("/server/%s/link/%s", firstServerId, secondServerId)
+	req, err := http.NewRequest("DELETE", url, nil)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("DetachLinkBetweenServers: Error on HTTP request: %s", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Non-200 response on detaching the organization from the server\nbody=%s", body)
 	}
 
 	return nil

--- a/internal/pritunl/link.go
+++ b/internal/pritunl/link.go
@@ -1,0 +1,10 @@
+package pritunl
+
+type Link struct {
+	ID              string `json:"id,omitempty"`
+	Name            string `json:"name,omitempty"`
+	Server          string `json:"server,omitempty"`
+	Status          string `json:"status,omitempty"`
+	UseLocalAddress bool   `json:"use_local_address,omitempty"`
+	Address         string `json:"address,omitempty"`
+}

--- a/internal/provider/resource_server.go
+++ b/internal/provider/resource_server.go
@@ -515,10 +515,12 @@ func resourceReadServer(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	// get routes
-	routes, err := apiClient.GetRoutesByServer(d.Id())
+	routesWithServerLinks, err := apiClient.GetRoutesByServer(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	routes := filterServerLinksForRoutes(routesWithServerLinks)
 
 	// get hosts
 	hosts, err := apiClient.GetHostsByServer(d.Id())
@@ -1176,4 +1178,15 @@ func matchStringEntitiesWithSchema(entities []string, declaredEntities []interfa
 	}
 
 	return result
+}
+
+func filterServerLinksForRoutes(routesWithServerLinks []pritunl.Route) []pritunl.Route {
+	routes := make([]pritunl.Route, 0)
+	for _, route := range routesWithServerLinks {
+		if route.ServerLink {
+			continue
+		}
+		routes = append(routes, route)
+	}
+	return routes
 }


### PR DESCRIPTION
Hello, 

I prepared this PR to solve problems when updating linked servers. Updating linked servers requires that all servers that have a connection with the one being updated be stopped.

Implemented the following features to solve this problem:
- added the ability to check, add and delete linked servers
- added filtering of routes based on the presence of server links