### PR TITLE
Fixed CI `GoReleaser` step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3.1.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically


### PR DESCRIPTION
Replaced `--rm-dist` to `--clean`
https://goreleaser.com/deprecations/#-rm-dist