### PR TITLE
Prevent unnecessary route recreation when reordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+.PHONY: build
 build:
 	go build -gcflags="all=-N -l" -o ~/.terraform.d/plugins/registry.terraform.io/disc/pritunl/0.0.1/darwin_amd64/terraform-provider-pritunl_v0.0.1 main.go
 
+.PHONY: test
 test:
 	@docker rm tf_pritunl_acc_test -f || true
 	@docker run --name tf_pritunl_acc_test --hostname pritunl.local --rm -d --privileged \
@@ -9,7 +11,7 @@ test:
 		-p 80:80/tcp \
 		-p 443:443/tcp \
 		-p 27017:27017/tcp \
-		ghcr.io/jippi/docker-pritunl:1.32.3602.80
+		ghcr.io/jippi/docker-pritunl:1.32.4399.86
 
 	sleep 20
 

--- a/internal/provider/resource_server.go
+++ b/internal/provider/resource_server.go
@@ -1114,22 +1114,21 @@ func flattenRoutesData(routesList []pritunl.Route) []interface{} {
 func matchRoutesWithSchema(routes []pritunl.Route, declaredRoutes []interface{}) []pritunl.Route {
 	result := make([]pritunl.Route, len(declaredRoutes))
 
-	routesMap := make(map[string]pritunl.Route, len(declaredRoutes))
+	routesMap := make(map[string]pritunl.Route)
 	for _, route := range routes {
-		routesMap[route.GetID()] = route
+		routesMap[route.Network] = route
 	}
 
 	for i, declaredRoute := range declaredRoutes {
 		declaredRouteMap := declaredRoute.(map[string]interface{})
+		network, ok := declaredRouteMap["network"].(string)
+		if !ok {
+			continue
+		}
 
-		for key, route := range routesMap {
-			if route.Network != declaredRouteMap["network"] || route.Nat != declaredRouteMap["nat"] || route.NetGateway != declaredRouteMap["net_gateway"] {
-				continue
-			}
-
-			result[i] = route
-			delete(routesMap, key)
-			break
+		if apiRoute, exists := routesMap[network]; exists {
+			result[i] = apiRoute
+			delete(routesMap, network)
 		}
 	}
 


### PR DESCRIPTION
Skip API calls when routes are reordered but unchanged
Fixes #98