### PR TITLE
Add chacha20poly1305-cipher support

### DIFF
--- a/internal/provider/resource_server.go
+++ b/internal/provider/resource_server.go
@@ -34,7 +34,7 @@ func resourceServer() *schema.Resource {
 				Optional:     true,
 				Description:  "The cipher for the server",
 				Default:      "aes128",
-				ValidateFunc: validation.StringInSlice([]string{"none", "bf128", "bf256", "aes128", "aes192", "aes256"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"none", "bf128", "bf256", "aes128", "aes192", "aes256", "chacha20poly1205"}, false),
 			},
 			"hash": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
## Summary
Adds `chacha20poly1305` to the list of valid cipher values for the `cipher` field on `pritunl_server`.

--
Please note the intentional typo: the value is `chacha20poly1205` (not `chacha20poly1305`) because Pritunl itself contains this value in its source code.
https://github.com/pritunl/pritunl/blob/ce436f6d4d37240eb2565c9223146d57f9767d4c/pritunl/constants.py#L1048

