### PR TITLE
Add computed profile_url/profile_uri to pritunl_user

### DIFF
--- a/internal/pritunl/client.go
+++ b/internal/pritunl/client.go
@@ -706,7 +706,10 @@ type KeyLink struct {
 
 func (c client) GetKeyLink(orgId, userId string) (*KeyLink, error) {
 	url := fmt.Sprintf("/data/%s/%s", orgId, userId)
-	req, _ := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetKeyLink: Error creating request: %s", err)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -714,9 +717,12 @@ func (c client) GetKeyLink(orgId, userId string) (*KeyLink, error) {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("GetKeyLink: Error reading response body: %s", err)
+	}
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Non-200 response on getting key link\nbody=%s", body)
+		return nil, fmt.Errorf("Non-200 response on getting key link\ncode=%d\nbody=%s", resp.StatusCode, body)
 	}
 
 	var link KeyLink

--- a/internal/pritunl/client.go
+++ b/internal/pritunl/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 type Client interface {
@@ -19,6 +20,7 @@ type Client interface {
 	DeleteOrganization(name string) error
 
 	GetUser(id string, orgId string) (*User, error)
+	GetKeyLink(orgId, userId string) (*KeyLink, error)
 	CreateUser(newUser User) (*User, error)
 	UpdateUser(id string, user *User) error
 	DeleteUser(id string, orgId string) error
@@ -697,6 +699,43 @@ func (c client) GetUser(id string, orgId string) (*User, error) {
 	return &user, nil
 }
 
+type KeyLink struct {
+	ViewUrl string `json:"view_url"`
+	UriUrl  string `json:"uri_url"`
+}
+
+func (c client) GetKeyLink(orgId, userId string) (*KeyLink, error) {
+	url := fmt.Sprintf("/data/%s/%s", orgId, userId)
+	req, _ := http.NewRequest("GET", url, nil)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GetKeyLink: Error on HTTP request: %s", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Non-200 response on getting key link\nbody=%s", body)
+	}
+
+	var link KeyLink
+	err = json.Unmarshal(body, &link)
+	if err != nil {
+		return nil, fmt.Errorf("GetKeyLink: %s, body=%s", err, body)
+	}
+
+	base := strings.TrimRight(c.baseUrl, "/")
+	if link.ViewUrl != "" {
+		link.ViewUrl = base + link.ViewUrl
+	}
+	if link.UriUrl != "" {
+		link.UriUrl = base + link.UriUrl
+	}
+
+	return &link, nil
+}
+
 func (c client) CreateUser(newUser User) (*User, error) {
 	jsonData, err := json.Marshal(newUser)
 	if err != nil {
@@ -871,5 +910,5 @@ func NewClient(baseUrl, apiToken, apiSecret string, insecure bool) Client {
 		},
 	}
 
-	return &client{httpClient: httpClient}
+	return &client{httpClient: httpClient, baseUrl: baseUrl}
 }

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -107,6 +107,16 @@ func resourceUser() *schema.Resource {
 				Sensitive:   true,
 				Description: "The PIN for user authentication.",
 			},
+			"profile_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Temporary profile page URL for the user.",
+			},
+			"profile_uri": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Temporary profile import URI for the user.",
+			},
 		},
 		CreateContext: resourceUserCreate,
 		ReadContext:   resourceUserRead,
@@ -321,6 +331,11 @@ func resourceUserCreate(_ context.Context, d *schema.ResourceData, meta interfac
 
 	d.SetId(user.ID)
 
+	if link, err := apiClient.GetKeyLink(d.Get("organization_id").(string), user.ID); err == nil {
+		d.Set("profile_url", link.ViewUrl)
+		d.Set("profile_uri", link.UriUrl)
+	}
+
 	return nil
 }
 
@@ -341,6 +356,11 @@ func resourceUserImport(_ context.Context, d *schema.ResourceData, meta interfac
 	_, err := apiClient.GetUser(userId, orgId)
 	if err != nil {
 		return nil, fmt.Errorf("error on getting user during import: %s", err)
+	}
+
+	if link, err := apiClient.GetKeyLink(orgId, userId); err == nil {
+		d.Set("profile_url", link.ViewUrl)
+		d.Set("profile_uri", link.UriUrl)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -110,11 +110,13 @@ func resourceUser() *schema.Resource {
 			"profile_url": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: "Temporary profile page URL for the user.",
 			},
 			"profile_uri": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: "Temporary profile import URI for the user.",
 			},
 		},


### PR DESCRIPTION
Expose a user's temporary profile page URL and import URI as computed attributes, fetched from the key data endpoint on create and import.